### PR TITLE
fix: Remove placeholder text

### DIFF
--- a/lib/rules/should-var-name/should-var-name.ts
+++ b/lib/rules/should-var-name/should-var-name.ts
@@ -19,8 +19,7 @@ export const shouldVarName = createRule<[], MessageIds>({
       requiresTypeChecking: false,
     },
     messages: {
-      [INVALID_VAR_NAME]:
-        "Invalid variable name for should-js. Configured variable names: {{names}}",
+      [INVALID_VAR_NAME]: "Invalid variable name for should-js.",
       [SUGGEST_FUNCTION_VAR_RENAME]: "Rename variable to: {{name}}",
     },
     schema: [],


### PR DESCRIPTION
I didn't check but it might not even be supported, but removed it because even if it is there could be the possibility of outputting a bunch of variables making the message hard to read, let the suggest fixes do the work.